### PR TITLE
fixed: hide password when returning user information

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",
+    "class-transformer": "^0.5.1",
     "express": "^4.17.2",
     "jest": "^27.4.5",
     "jsonwebtoken": "^8.5.1",

--- a/src/modules/accounts/dtos/UserResponseDTO.ts
+++ b/src/modules/accounts/dtos/UserResponseDTO.ts
@@ -1,0 +1,10 @@
+interface IUserResponseDTO {
+  id?: string;
+  name: string;
+  email: string;
+  favTeam?: string;
+  avatar?: string;
+  profile?: string;
+}
+
+export { IUserResponseDTO };

--- a/src/modules/accounts/mapper/UserMap.ts
+++ b/src/modules/accounts/mapper/UserMap.ts
@@ -1,0 +1,28 @@
+import { User } from '../entities/User';
+import { IUserResponseDTO } from '../dtos/UserResponseDTO';
+import { instanceToInstance } from 'class-transformer';
+
+class UserMap {
+  static toDto({
+    id,
+    name,
+    email,
+    avatar,
+    profile,
+    favTeam,
+    created_at,
+  }: User): IUserResponseDTO {
+    const user = instanceToInstance({
+      id,
+      name,
+      email,
+      avatar,
+      profile,
+      favTeam,
+      created_at,
+    });
+    return user;
+  }
+}
+
+export { UserMap };

--- a/src/modules/accounts/useCases/createUser/CreateUserUseCase.ts
+++ b/src/modules/accounts/useCases/createUser/CreateUserUseCase.ts
@@ -2,8 +2,10 @@ import { User } from '../../entities/User';
 import { AppError } from '@shared/errors/AppError';
 import { ICreateUserDTO } from '../../dtos/CreateUserDTO';
 import { IUserRepository } from '../../repositories/IUserRepository';
+import { UserMap } from '@modules/accounts/mapper/UserMap';
 
 import { hash } from 'bcryptjs';
+import { IUserResponseDTO } from '@modules/accounts/dtos/UserResponseDTO';
 
 class CreateUserUseCase {
   constructor(private usersRepository: IUserRepository) {}
@@ -15,7 +17,7 @@ class CreateUserUseCase {
     favTeam,
     profile,
     avatar,
-  }: ICreateUserDTO): Promise<User> {
+  }: ICreateUserDTO): Promise<IUserResponseDTO> {
     if (!email || !/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/.test(email))
       throw new AppError('E-Mail address is invalid.', 400);
 
@@ -35,7 +37,8 @@ class CreateUserUseCase {
       profile,
       avatar,
     });
-    return newUser;
+    const user = UserMap.toDto(newUser);
+    return user;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1214,6 +1214,11 @@ cjs-module-lexer@^1.0.0:
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz#9f84ba3244a512f3a54e5277e8eef4c489864e40"
   integrity sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==
 
+class-transformer@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/class-transformer/-/class-transformer-0.5.1.tgz#24147d5dffd2a6cea930a3250a677addf96ab336"
+  integrity sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==
+
 cli-highlight@^2.1.11:
   version "2.1.11"
   resolved "https://registry.yarnpkg.com/cli-highlight/-/cli-highlight-2.1.11.tgz#49736fa452f0aaf4fae580e30acb26828d2dc1bf"


### PR DESCRIPTION
Added `class-transformer` as a dependency.

Implemented a user mapper to return only not sensible information about user. The mapper use the method `classToClass` from class transformer to convert user instance to a new one without the password field. Implemented a DTO to handle the user return type.

This implementation breaks the test should encrypt password.