### PR TITLE
implemented admin account seed

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "start": "node src/server.ts",
     "typeorm": "ts-node-dev -r tsconfig-paths/register ./node_modules/typeorm/cli",
     "test": "NODE_ENV=test jest --runInBand --detectOpenHandles",
-    "test:watch": "NODE_ENV=test jest --runInBand --detectOpenHandles --verbose --watchAll"
+    "test:watch": "NODE_ENV=test jest --runInBand --detectOpenHandles --verbose --watchAll",
+    "seed:admin": "ts-node-dev ./src/shared/infra/typeorm/seeds/admin.ts"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/src/shared/infra/typeorm/migrations/1640887954203-AddAdminFieldUsersTable.ts
+++ b/src/shared/infra/typeorm/migrations/1640887954203-AddAdminFieldUsersTable.ts
@@ -1,0 +1,20 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddAdminFieldUsersTable1640887954203
+  implements MigrationInterface
+{
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'users',
+      new TableColumn({
+        name: 'isAdmin',
+        type: 'boolean',
+        default: 'FALSE',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('users', 'isAdmin');
+  }
+}

--- a/src/shared/infra/typeorm/seeds/admin.ts
+++ b/src/shared/infra/typeorm/seeds/admin.ts
@@ -1,0 +1,21 @@
+import { hash } from 'bcryptjs';
+import { v4 as uuidV4 } from 'uuid';
+
+import createConnection from '../index';
+
+async function create() {
+  const connection = await createConnection();
+
+  const id = uuidV4();
+
+  const password = await hash('admin', 8);
+
+  await connection.query(
+    `INSERT INTO USERS(id,name,email,password,"isAdmin","favTeam","profile","avatar")
+    VALUES('${id}','admin','bignotto@gmail.com','${password}',true,'','','')`,
+  );
+
+  await connection.close();
+}
+
+create().then(() => console.log('admin user created'));


### PR DESCRIPTION
Created a seed file `admin.ts` in `src/infra/typeorm/seeds`.

This script creates a connection to database, runs a simple sql query to direct insert the admin user into users table. Also add a script command in package.json.

To seed the database run this command:

```bash
yarn seed:admin
```