### PR TITLE
Feature/groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "pg": "^8.7.1",
     "prisma": "^3.7.0",
     "reflect-metadata": "^0.1.13",
+    "short-unique-id": "^4.4.4",
     "tsyringe": "^4.6.0",
     "typeorm": "^0.2.41",
     "uuid": "^8.3.2"

--- a/src/modules/accounts/entities/User.ts
+++ b/src/modules/accounts/entities/User.ts
@@ -12,7 +12,7 @@ class User {
   @Column()
   name: string;
 
-  @Column()
+  @Column({ select: false })
   password: string;
 
   @Column()

--- a/src/modules/accounts/entities/User.ts
+++ b/src/modules/accounts/entities/User.ts
@@ -12,7 +12,7 @@ class User {
   @Column()
   name: string;
 
-  @Column({ select: false })
+  @Column()
   password: string;
 
   @Column()

--- a/src/modules/groups/dtos/ICreateGroupDTO.ts
+++ b/src/modules/groups/dtos/ICreateGroupDTO.ts
@@ -1,7 +1,7 @@
 import { User } from '@modules/accounts/entities/User';
 
 interface ICreateGroupDTO {
-  id?: number;
+  id?: string;
   description: string;
   owner_id: string;
   password: string;

--- a/src/modules/groups/dtos/ICreateGroupDTO.ts
+++ b/src/modules/groups/dtos/ICreateGroupDTO.ts
@@ -1,0 +1,11 @@
+import { User } from '@modules/accounts/entities/User';
+
+interface ICreateGroupDTO {
+  id?: number;
+  description: string;
+  owner_id: User;
+  password: string;
+  users?: User[];
+}
+
+export { ICreateGroupDTO };

--- a/src/modules/groups/dtos/ICreateGroupDTO.ts
+++ b/src/modules/groups/dtos/ICreateGroupDTO.ts
@@ -3,7 +3,7 @@ import { User } from '@modules/accounts/entities/User';
 interface ICreateGroupDTO {
   id?: number;
   description: string;
-  owner_id: User;
+  owner_id: string;
   password: string;
   users?: User[];
 }

--- a/src/modules/groups/entities/Group.ts
+++ b/src/modules/groups/entities/Group.ts
@@ -1,5 +1,4 @@
 import { User } from '@modules/accounts/entities/User';
-import { Match } from '@modules/matches/entities/Match';
 import {
   Column,
   Entity,

--- a/src/modules/groups/entities/Group.ts
+++ b/src/modules/groups/entities/Group.ts
@@ -30,5 +30,7 @@ class Group {
     joinColumns: [{ name: 'group_id' }],
     inverseJoinColumns: [{ name: 'user_id' }],
   })
-  users: User[];
+  users?: User[];
 }
+
+export { Group };

--- a/src/modules/groups/entities/Group.ts
+++ b/src/modules/groups/entities/Group.ts
@@ -19,7 +19,10 @@ class Group {
 
   @ManyToOne(() => User)
   @JoinColumn({ name: 'id' })
-  owner_id: User;
+  owner: User;
+
+  @Column()
+  owner_id: string;
 
   @Column()
   password: string;

--- a/src/modules/groups/entities/Group.ts
+++ b/src/modules/groups/entities/Group.ts
@@ -1,0 +1,35 @@
+import { User } from '@modules/accounts/entities/User';
+import { Match } from '@modules/matches/entities/Match';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  PrimaryColumn,
+} from 'typeorm';
+
+@Entity('groups')
+class Group {
+  @PrimaryColumn()
+  id: number;
+
+  @Column()
+  description: string;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'id' })
+  owner_id: User;
+
+  @Column()
+  password: string;
+
+  @ManyToMany(() => User)
+  @JoinTable({
+    name: 'groups_users',
+    joinColumns: [{ name: 'group_id' }],
+    inverseJoinColumns: [{ name: 'user_id' }],
+  })
+  users: User[];
+}

--- a/src/modules/groups/entities/Group.ts
+++ b/src/modules/groups/entities/Group.ts
@@ -9,10 +9,13 @@ import {
   PrimaryColumn,
 } from 'typeorm';
 
+import ShortUniqueId from 'short-unique-id';
+const uid = new ShortUniqueId({ length: 8 });
+
 @Entity('groups')
 class Group {
   @PrimaryColumn()
-  id: number;
+  id: string;
 
   @Column()
   description: string;
@@ -34,6 +37,10 @@ class Group {
     inverseJoinColumns: [{ name: 'user_id' }],
   })
   users?: User[];
+
+  constructor() {
+    if (!this.id) this.id = uid();
+  }
 }
 
 export { Group };

--- a/src/modules/groups/repositories/IGroupRepository.ts
+++ b/src/modules/groups/repositories/IGroupRepository.ts
@@ -1,8 +1,8 @@
 import { ICreateGroupDTO } from '../dtos/ICreateGroupDTO';
 import { Group } from '../entities/Group';
 
-interface IGropupRepository {
+interface IGroupRepository {
   create(data: ICreateGroupDTO): Promise<Group>;
 }
 
-export { IGropupRepository };
+export { IGroupRepository };

--- a/src/modules/groups/repositories/IGroupRepository.ts
+++ b/src/modules/groups/repositories/IGroupRepository.ts
@@ -1,0 +1,8 @@
+import { ICreateGroupDTO } from '../dtos/ICreateGroupDTO';
+import { Group } from '../entities/Group';
+
+interface IGropupRepository {
+  create(data: ICreateGroupDTO): Promise<Group>;
+}
+
+export { IGropupRepository };

--- a/src/modules/groups/repositories/inMemory/GroupInMemoryRepository.ts
+++ b/src/modules/groups/repositories/inMemory/GroupInMemoryRepository.ts
@@ -1,0 +1,28 @@
+import { ICreateGroupDTO } from '@modules/groups/dtos/ICreateGroupDTO';
+import { Group } from '@modules/groups/entities/Group';
+import { IGroupRepository } from '../IGroupRepository';
+
+class GroupInMemoryRepository implements IGroupRepository {
+  groups: Group[] = [];
+
+  create({
+    id,
+    description,
+    owner_id,
+    password,
+    users,
+  }: ICreateGroupDTO): Promise<Group> {
+    const group = new Group();
+    Object.assign(group, {
+      id,
+      description,
+      owner_id,
+      password,
+      users,
+    });
+    this.groups.push(group);
+    return Promise.resolve(group);
+  }
+}
+
+export { GroupInMemoryRepository };

--- a/src/modules/groups/repositories/typeorm/GroupTypeOrmRepository.ts
+++ b/src/modules/groups/repositories/typeorm/GroupTypeOrmRepository.ts
@@ -2,9 +2,9 @@ import { getRepository, Repository } from 'typeorm';
 
 import { ICreateGroupDTO } from '@modules/groups/dtos/ICreateGroupDTO';
 import { Group } from '@modules/groups/entities/Group';
-import { IGropupRepository } from '../IGroupRepository';
+import { IGroupRepository } from '../IGroupRepository';
 
-class GroupTypeOrmRepository implements IGropupRepository {
+class GroupTypeOrmRepository implements IGroupRepository {
   private repository: Repository<Group>;
 
   constructor() {
@@ -31,3 +31,5 @@ class GroupTypeOrmRepository implements IGropupRepository {
     return newGroup;
   }
 }
+
+export { GroupTypeOrmRepository };

--- a/src/modules/groups/repositories/typeorm/GroupTypeOrmRepository.ts
+++ b/src/modules/groups/repositories/typeorm/GroupTypeOrmRepository.ts
@@ -1,0 +1,33 @@
+import { getRepository, Repository } from 'typeorm';
+
+import { ICreateGroupDTO } from '@modules/groups/dtos/ICreateGroupDTO';
+import { Group } from '@modules/groups/entities/Group';
+import { IGropupRepository } from '../IGroupRepository';
+
+class GroupTypeOrmRepository implements IGropupRepository {
+  private repository: Repository<Group>;
+
+  constructor() {
+    this.repository = getRepository(Group);
+  }
+
+  async create({
+    id,
+    description,
+    owner_id,
+    password,
+    users,
+  }: ICreateGroupDTO): Promise<Group> {
+    const newGroup = await this.repository.create({
+      id,
+      description,
+      owner_id,
+      password,
+      users,
+    });
+
+    await this.repository.save(newGroup);
+
+    return newGroup;
+  }
+}

--- a/src/modules/groups/useCases/createGroup/CreateGroupController.ts
+++ b/src/modules/groups/useCases/createGroup/CreateGroupController.ts
@@ -1,0 +1,21 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+import { CreateGroupUseCase } from './CreateGroupUseCase';
+
+class CreateGroupController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    const { description, password } = request.body;
+    const { id } = request.user;
+
+    const createGroup = container.resolve(CreateGroupUseCase);
+    const result = await createGroup.execute({
+      description,
+      password,
+      owner_id: id,
+    });
+
+    return response.status(201).json(result);
+  }
+}
+
+export { CreateGroupController };

--- a/src/modules/groups/useCases/createGroup/CreateGroupUseCase.spec.ts
+++ b/src/modules/groups/useCases/createGroup/CreateGroupUseCase.spec.ts
@@ -1,0 +1,40 @@
+import { User } from '@modules/accounts/entities/User';
+import { UserInMemoryRepository } from '@modules/accounts/repositories/inMemory/UserInMemoryRepository';
+import { CreateUserUseCase } from '@modules/accounts/useCases/createUser/CreateUserUseCase';
+import { GroupInMemoryRepository } from '@modules/groups/repositories/inMemory/GroupInMemoryRepository';
+import { CreateGroupUseCase } from './CreateGroupUseCase';
+
+let createGroupUseCase: CreateGroupUseCase;
+let groupRepository: GroupInMemoryRepository;
+
+let createUserUseCase: CreateUserUseCase;
+let userRepository: UserInMemoryRepository;
+
+describe('Create Group Use Case', () => {
+  beforeEach(() => {
+    groupRepository = new GroupInMemoryRepository();
+    createGroupUseCase = new CreateGroupUseCase(groupRepository);
+
+    userRepository = new UserInMemoryRepository();
+    createUserUseCase = new CreateUserUseCase(userRepository);
+  });
+
+  it('should be able to create a new group', async () => {
+    const user = new User();
+    Object.assign(user, {
+      name: 'Test Dude',
+      email: 'dude@test.com',
+      password: '123456',
+    });
+
+    const createdGroup = await createGroupUseCase.execute({
+      description: 'Test Group',
+      owner_id: user.id,
+      password: '123',
+      users: [user],
+    });
+
+    console.log(createdGroup);
+    expect(createdGroup).toHaveProperty('id');
+  });
+});

--- a/src/modules/groups/useCases/createGroup/CreateGroupUseCase.spec.ts
+++ b/src/modules/groups/useCases/createGroup/CreateGroupUseCase.spec.ts
@@ -2,6 +2,7 @@ import { User } from '@modules/accounts/entities/User';
 import { UserInMemoryRepository } from '@modules/accounts/repositories/inMemory/UserInMemoryRepository';
 import { CreateUserUseCase } from '@modules/accounts/useCases/createUser/CreateUserUseCase';
 import { GroupInMemoryRepository } from '@modules/groups/repositories/inMemory/GroupInMemoryRepository';
+import { AppError } from '@shared/errors/AppError';
 import { CreateGroupUseCase } from './CreateGroupUseCase';
 
 let createGroupUseCase: CreateGroupUseCase;
@@ -30,13 +31,48 @@ describe('Create Group Use Case', () => {
       password: '123456',
     });
 
+    const createdUser = await createUserUseCase.execute(user);
+    user.id = createdUser.id;
+
     const createdGroup = await createGroupUseCase.execute({
       description: 'Test Group',
-      owner_id: user.id,
+      owner_id: createdUser.id,
       password: '123',
       users: [user],
     });
 
     expect(createdGroup).toHaveProperty('id');
+  });
+
+  it('should not be able to create a group when invalid user id is passed', async () => {
+    await expect(() =>
+      createGroupUseCase.execute({
+        description: 'Test Group',
+        owner_id: 'invalid id',
+        password: '123',
+      }),
+    ).rejects.toBeInstanceOf(AppError);
+  });
+
+  it(`group owner should be in the group's users array`, async () => {
+    const user = new User();
+    Object.assign(user, {
+      name: 'Test Dude',
+      email: 'dude@test.com',
+      password: '123456',
+    });
+
+    const createdUser = await createUserUseCase.execute(user);
+    user.id = createdUser.id;
+
+    const createdGroup = await createGroupUseCase.execute({
+      description: 'Test Group',
+      owner_id: createdUser.id,
+      password: '123',
+      users: [user],
+    });
+
+    expect(createdGroup.users.length).toBe(1);
+    expect(createdGroup.owner_id).toEqual(createdGroup.users[0].id);
   });
 });

--- a/src/modules/groups/useCases/createGroup/CreateGroupUseCase.spec.ts
+++ b/src/modules/groups/useCases/createGroup/CreateGroupUseCase.spec.ts
@@ -13,9 +13,12 @@ let userRepository: UserInMemoryRepository;
 describe('Create Group Use Case', () => {
   beforeEach(() => {
     groupRepository = new GroupInMemoryRepository();
-    createGroupUseCase = new CreateGroupUseCase(groupRepository);
-
     userRepository = new UserInMemoryRepository();
+
+    createGroupUseCase = new CreateGroupUseCase(
+      groupRepository,
+      userRepository,
+    );
     createUserUseCase = new CreateUserUseCase(userRepository);
   });
 
@@ -34,7 +37,6 @@ describe('Create Group Use Case', () => {
       users: [user],
     });
 
-    console.log(createdGroup);
     expect(createdGroup).toHaveProperty('id');
   });
 });

--- a/src/modules/groups/useCases/createGroup/CreateGroupUseCase.ts
+++ b/src/modules/groups/useCases/createGroup/CreateGroupUseCase.ts
@@ -25,13 +25,8 @@ class CreateGroupUseCase {
       description,
       owner_id,
       password,
+      users: [owner],
     });
-
-    group.users = [owner];
-
-    console.log({ group });
-
-    await this.groupRepository.create(group);
 
     return group;
   }

--- a/src/modules/groups/useCases/createGroup/CreateGroupUseCase.ts
+++ b/src/modules/groups/useCases/createGroup/CreateGroupUseCase.ts
@@ -1,0 +1,31 @@
+import { inject, injectable } from 'tsyringe';
+
+import { IGroupRepository } from '../../repositories/IGroupRepository';
+
+import { Group } from '@modules/groups/entities/Group';
+import { ICreateGroupDTO } from '@modules/groups/dtos/ICreateGroupDTO';
+
+@injectable()
+class CreateGroupUseCase {
+  constructor(
+    @inject('GroupRepository') private groupRepository: IGroupRepository,
+  ) {}
+
+  async execute({
+    description,
+    owner_id,
+    password,
+    users,
+  }: ICreateGroupDTO): Promise<Group> {
+    const group = await this.groupRepository.create({
+      description,
+      owner_id,
+      password,
+      users,
+    });
+
+    return group;
+  }
+}
+
+export { CreateGroupUseCase };

--- a/src/modules/groups/useCases/createGroup/CreateGroupUseCase.ts
+++ b/src/modules/groups/useCases/createGroup/CreateGroupUseCase.ts
@@ -5,6 +5,7 @@ import { IGroupRepository } from '../../repositories/IGroupRepository';
 import { Group } from '@modules/groups/entities/Group';
 import { ICreateGroupDTO } from '@modules/groups/dtos/ICreateGroupDTO';
 import { IUserRepository } from '@modules/accounts/repositories/IUserRepository';
+import { AppError } from '@shared/errors/AppError';
 
 @injectable()
 class CreateGroupUseCase {
@@ -20,12 +21,15 @@ class CreateGroupUseCase {
     users,
   }: ICreateGroupDTO): Promise<Group> {
     const owner = await this.userRepository.findById(owner_id);
+    if (!owner) throw new AppError('Invalid user', 400);
+
+    if (!users) users.push(owner);
 
     const group = await this.groupRepository.create({
       description,
       owner_id,
       password,
-      users: [owner],
+      users,
     });
 
     return group;

--- a/src/modules/groups/useCases/createGroup/CreateGroupUseCase.ts
+++ b/src/modules/groups/useCases/createGroup/CreateGroupUseCase.ts
@@ -4,11 +4,13 @@ import { IGroupRepository } from '../../repositories/IGroupRepository';
 
 import { Group } from '@modules/groups/entities/Group';
 import { ICreateGroupDTO } from '@modules/groups/dtos/ICreateGroupDTO';
+import { IUserRepository } from '@modules/accounts/repositories/IUserRepository';
 
 @injectable()
 class CreateGroupUseCase {
   constructor(
     @inject('GroupRepository') private groupRepository: IGroupRepository,
+    @inject('UsersRepository') private userRepository: IUserRepository,
   ) {}
 
   async execute({
@@ -17,12 +19,19 @@ class CreateGroupUseCase {
     password,
     users,
   }: ICreateGroupDTO): Promise<Group> {
+    const owner = await this.userRepository.findById(owner_id);
+
     const group = await this.groupRepository.create({
       description,
       owner_id,
       password,
-      users,
     });
+
+    group.users = [owner];
+
+    console.log({ group });
+
+    await this.groupRepository.create(group);
 
     return group;
   }

--- a/src/shared/container/index.ts
+++ b/src/shared/container/index.ts
@@ -3,7 +3,15 @@ import { container } from 'tsyringe';
 import { UserTypeOrmRepository } from '@modules/accounts/repositories/typeorm/UserTypeOrmRepository';
 import { IUserRepository } from '@modules/accounts/repositories/IUserRepository';
 
+import { GroupTypeOrmRepository } from '@modules/groups/repositories/typeorm/GroupTypeOrmRepository';
+import { IGroupRepository } from '@modules/groups/repositories/IGroupRepository';
+
 container.registerSingleton<IUserRepository>(
   'UsersRepository',
   UserTypeOrmRepository,
+);
+
+container.registerSingleton<IGroupRepository>(
+  'GroupRepository',
+  GroupTypeOrmRepository,
 );

--- a/src/shared/infra/http/app.ts
+++ b/src/shared/infra/http/app.ts
@@ -7,6 +7,7 @@ import createConnection from '../typeorm';
 
 import { usersRoutes } from './routes/users.routes';
 import { authRoutes } from './routes/authentication.routes';
+import { groupsRoutes } from './routes/groups.routes';
 
 import { AppError } from '@shared/errors/AppError';
 
@@ -20,6 +21,7 @@ app.use(express.json());
 
 app.use('/users', usersRoutes);
 app.use('/auth', authRoutes);
+app.use('/groups', groupsRoutes);
 
 app.get('/', (request, response) =>
   response.status(200).json({
@@ -41,7 +43,7 @@ app.use(
     return response.status(500).json({
       status: 'error',
       message: `Internal server error - ${err.message}`,
-      err,
+      erro: err,
     });
   },
 );

--- a/src/shared/infra/http/routes/groups.routes.ts
+++ b/src/shared/infra/http/routes/groups.routes.ts
@@ -1,0 +1,11 @@
+import { CreateGroupController } from '@modules/groups/useCases/createGroup/CreateGroupController';
+import { Router } from 'express';
+import { ensureAuthenticated } from '../middlewares/ensureAuthenticated';
+
+const createGroupController = new CreateGroupController();
+
+const groupsRoutes = Router();
+
+groupsRoutes.post('/', ensureAuthenticated, createGroupController.handle);
+
+export { groupsRoutes };

--- a/src/shared/infra/typeorm/migrations/1641132749647-CreateGroupsTable.ts
+++ b/src/shared/infra/typeorm/migrations/1641132749647-CreateGroupsTable.ts
@@ -8,10 +8,8 @@ export class CreateGroupsTable1641132749647 implements MigrationInterface {
         columns: [
           {
             name: 'id',
-            type: 'int',
+            type: 'varchar',
             isPrimary: true,
-            isGenerated: true,
-            generationStrategy: 'increment',
           },
           {
             name: 'description',

--- a/src/shared/infra/typeorm/migrations/1641132749647-CreateGroupsTable.ts
+++ b/src/shared/infra/typeorm/migrations/1641132749647-CreateGroupsTable.ts
@@ -1,0 +1,45 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateGroupsTable1641132749647 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'groups',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+          },
+          {
+            name: 'description',
+            type: 'varchar',
+          },
+          {
+            name: 'owner_id',
+            type: 'uuid',
+          },
+          {
+            name: 'password',
+            type: 'varchar',
+          },
+        ],
+        foreignKeys: [
+          {
+            name: 'FK_GroupOwner',
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            columnNames: ['owner_id'],
+            onDelete: 'SET NULL',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('groups');
+  }
+}

--- a/src/shared/infra/typeorm/migrations/1641133334988-CreateGroupsUsersTable.ts
+++ b/src/shared/infra/typeorm/migrations/1641133334988-CreateGroupsUsersTable.ts
@@ -1,0 +1,53 @@
+import {
+  MigrationInterface,
+  QueryRunner,
+  Table,
+  TableForeignKey,
+} from 'typeorm';
+
+export class CreateGroupsUsersTable1641133334988 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'groups_users',
+        columns: [
+          {
+            name: 'group_id',
+            type: 'int',
+          },
+          {
+            name: 'user_id',
+            type: 'uuid',
+          },
+        ],
+      }),
+    );
+
+    await queryRunner.createForeignKey(
+      'groups_users',
+      new TableForeignKey({
+        name: 'FK_GroupUser',
+        referencedTableName: 'groups',
+        referencedColumnNames: ['id'],
+        columnNames: ['group_id'],
+        onDelete: 'SET NULL',
+      }),
+    );
+    await queryRunner.createForeignKey(
+      'groups_users',
+      new TableForeignKey({
+        name: 'FK_UserGroup',
+        referencedTableName: 'users',
+        referencedColumnNames: ['id'],
+        columnNames: ['user_id'],
+        onDelete: 'SET NULL',
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropForeignKey('groups_users', 'FK_GroupUser');
+    await queryRunner.dropForeignKey('groups_users', 'FK_UserGroup');
+    await queryRunner.dropTable('groups_users');
+  }
+}

--- a/src/shared/infra/typeorm/migrations/1641133334988-CreateGroupsUsersTable.ts
+++ b/src/shared/infra/typeorm/migrations/1641133334988-CreateGroupsUsersTable.ts
@@ -13,7 +13,7 @@ export class CreateGroupsUsersTable1641133334988 implements MigrationInterface {
         columns: [
           {
             name: 'group_id',
-            type: 'int',
+            type: 'varchar',
           },
           {
             name: 'user_id',

--- a/tools/generate.js
+++ b/tools/generate.js
@@ -16,7 +16,7 @@ generateTemplateFiles([
       pathAndFileNameDefaultCase: CaseConverterEnum.PascalCase,
     },
     onComplete: results => {
-      console.log(`results`, results);
+      console.log({ results });
     },
   },
 ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3877,6 +3877,11 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+short-unique-id@^4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/short-unique-id/-/short-unique-id-4.4.4.tgz#a45df68303bbd2dbb5785ed7708e891809c9cb7a"
+  integrity sha512-oLF1NCmtbiTWl2SqdXZQbo5KM1b7axdp0RgQLq8qCBBLoq+o3A5wmLrNM6bZIh54/a8BJ3l69kTXuxwZ+XCYuw==
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"


### PR DESCRIPTION
- Implemented `Group` entity.
    
    Group id is now a short unique id.
    
    It was not returning the `id` field when creating a new group with an auto generated id value, so it will generates a unique short id in the constructor if no id is passed.
    
- Added a many to many relation to bring group's participant users
- Implemented `IGroupRepository` interface.
- Implemented `TypeORM` and `InMemory` repositories.
- Implemented `CreateGroup` use case and controller.
- Implemented a new route to handle creating new groups.
    
    POST `/groups`