### PR TITLE
Feature/guesses

### DIFF
--- a/src/modules/groups/dtos/ICreateGuessDTO.ts
+++ b/src/modules/groups/dtos/ICreateGuessDTO.ts
@@ -1,0 +1,10 @@
+interface ICreateGuessDTO {
+  id?: number;
+  match_id: number;
+  user_id: string;
+  group_id: string;
+  home_team: number;
+  away_team: number;
+}
+
+export { ICreateGuessDTO };

--- a/src/modules/groups/entities/Guess.ts
+++ b/src/modules/groups/entities/Guess.ts
@@ -1,6 +1,5 @@
 import { User } from '@modules/accounts/entities/User';
 import { Match } from '@modules/matches/entities/Match';
-import { Team } from '@modules/matches/entities/Team';
 import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
 import { Group } from './Group';
 
@@ -25,6 +24,9 @@ class Guess {
 
   @ManyToOne(() => Group)
   @JoinColumn({ name: 'id' })
+  group: Group;
+
+  @Column()
   group_id: string;
 
   @Column()

--- a/src/modules/groups/entities/Guess.ts
+++ b/src/modules/groups/entities/Guess.ts
@@ -11,22 +11,26 @@ class Guess {
 
   @ManyToOne(() => Match)
   @JoinColumn({ name: 'id' })
-  match_id: Match;
+  match: Match;
+
+  @Column()
+  match_id: number;
 
   @ManyToOne(() => User)
   @JoinColumn({ name: 'id' })
+  user: User;
+
+  @Column()
   user_id: string;
 
   @ManyToOne(() => Group)
   @JoinColumn({ name: 'id' })
   group_id: string;
 
-  @ManyToOne(() => Team)
-  @JoinColumn({ name: 'country_code' })
+  @Column()
   home_team: number;
 
-  @ManyToOne(() => Team)
-  @JoinColumn({ name: 'country_code' })
+  @Column()
   away_team: number;
 }
 

--- a/src/modules/groups/entities/Guess.ts
+++ b/src/modules/groups/entities/Guess.ts
@@ -1,0 +1,33 @@
+import { User } from '@modules/accounts/entities/User';
+import { Match } from '@modules/matches/entities/Match';
+import { Team } from '@modules/matches/entities/Team';
+import { Column, Entity, JoinColumn, ManyToOne, PrimaryColumn } from 'typeorm';
+import { Group } from './Group';
+
+@Entity('guesses')
+class Guess {
+  @PrimaryColumn()
+  id: number;
+
+  @ManyToOne(() => Match)
+  @JoinColumn({ name: 'id' })
+  match_id: Match;
+
+  @ManyToOne(() => User)
+  @JoinColumn({ name: 'id' })
+  user_id: string;
+
+  @ManyToOne(() => Group)
+  @JoinColumn({ name: 'id' })
+  group_id: string;
+
+  @ManyToOne(() => Team)
+  @JoinColumn({ name: 'country_code' })
+  home_team: number;
+
+  @ManyToOne(() => Team)
+  @JoinColumn({ name: 'country_code' })
+  away_team: number;
+}
+
+export { Guess };

--- a/src/modules/groups/repositories/IGroupRepository.ts
+++ b/src/modules/groups/repositories/IGroupRepository.ts
@@ -3,6 +3,7 @@ import { Group } from '../entities/Group';
 
 interface IGroupRepository {
   create(data: ICreateGroupDTO): Promise<Group>;
+  findById(group_id: string): Promise<Group>;
 }
 
 export { IGroupRepository };

--- a/src/modules/groups/repositories/IGuessRepository.ts
+++ b/src/modules/groups/repositories/IGuessRepository.ts
@@ -1,0 +1,8 @@
+import { ICreateGuessDTO } from '../dtos/ICreateGuessDTO';
+import { Guess } from '../entities/Guess';
+
+interface IGuessRepository {
+  create(data: ICreateGuessDTO): Promise<Guess>;
+}
+
+export { IGuessRepository };

--- a/src/modules/groups/repositories/IGuessRepository.ts
+++ b/src/modules/groups/repositories/IGuessRepository.ts
@@ -1,8 +1,16 @@
 import { ICreateGuessDTO } from '../dtos/ICreateGuessDTO';
 import { Guess } from '../entities/Guess';
 
-interface IGuessRepository {
-  create(data: ICreateGuessDTO): Promise<Guess>;
+interface IGroupMatchUser {
+  group_id: string;
+  match_id: number;
+  user_id: string;
 }
 
-export { IGuessRepository };
+interface IGuessRepository {
+  create(data: ICreateGuessDTO): Promise<Guess>;
+  findByUserId(user_id: string): Promise<Guess[]>;
+  findByGroupMatchUser(data: IGroupMatchUser): Promise<Guess>;
+}
+
+export { IGuessRepository, IGroupMatchUser };

--- a/src/modules/groups/repositories/inMemory/GroupInMemoryRepository.ts
+++ b/src/modules/groups/repositories/inMemory/GroupInMemoryRepository.ts
@@ -23,6 +23,11 @@ class GroupInMemoryRepository implements IGroupRepository {
     this.groups.push(group);
     return Promise.resolve(group);
   }
+
+  findById(group_id: string): Promise<Group> {
+    const found = this.groups.find(g => g.id === group_id);
+    return Promise.resolve(found);
+  }
 }
 
 export { GroupInMemoryRepository };

--- a/src/modules/groups/repositories/inMemory/GuessInMemoryRepository.ts
+++ b/src/modules/groups/repositories/inMemory/GuessInMemoryRepository.ts
@@ -1,9 +1,28 @@
 import { ICreateGuessDTO } from '@modules/groups/dtos/ICreateGuessDTO';
 import { Guess } from '@modules/groups/entities/Guess';
-import { IGuessRepository } from '../IGuessRepository';
+import { IGroupMatchUser, IGuessRepository } from '../IGuessRepository';
 
 class GuessInMemoryRepository implements IGuessRepository {
   guesses: Guess[] = [];
+
+  findByUserId(user_id: string): Promise<Guess[]> {
+    const found = this.guesses.filter(g => g.user_id === user_id);
+    return Promise.resolve(found);
+  }
+
+  findByGroupMatchUser({
+    group_id,
+    match_id,
+    user_id,
+  }: IGroupMatchUser): Promise<Guess> {
+    const found = this.guesses.find(
+      g =>
+        g.user_id === user_id &&
+        g.group_id === group_id &&
+        g.match_id === match_id,
+    );
+    return Promise.resolve(found);
+  }
 
   create({
     id,

--- a/src/modules/groups/repositories/inMemory/GuessInMemoryRepository.ts
+++ b/src/modules/groups/repositories/inMemory/GuessInMemoryRepository.ts
@@ -1,0 +1,30 @@
+import { ICreateGuessDTO } from '@modules/groups/dtos/ICreateGuessDTO';
+import { Guess } from '@modules/groups/entities/Guess';
+import { IGuessRepository } from '../IGuessRepository';
+
+class GuessInMemoryRepository implements IGuessRepository {
+  guesses: Guess[] = [];
+
+  create({
+    id,
+    user_id,
+    group_id,
+    match_id,
+    home_team,
+    away_team,
+  }: ICreateGuessDTO): Promise<Guess> {
+    const guess = new Guess();
+    Object.assign(guess, {
+      id,
+      user_id,
+      group_id,
+      match_id,
+      home_team,
+      away_team,
+    });
+    this.guesses.push(guess);
+    return Promise.resolve(guess);
+  }
+}
+
+export { GuessInMemoryRepository };

--- a/src/modules/groups/repositories/typeorm/GroupTypeOrmRepository.ts
+++ b/src/modules/groups/repositories/typeorm/GroupTypeOrmRepository.ts
@@ -30,6 +30,11 @@ class GroupTypeOrmRepository implements IGroupRepository {
 
     return newGroup;
   }
+
+  async findById(group_id: string): Promise<Group> {
+    const found = await this.repository.findOne({ id: group_id });
+    return found;
+  }
 }
 
 export { GroupTypeOrmRepository };

--- a/src/modules/groups/repositories/typeorm/GuessTypeOrmRepository.ts
+++ b/src/modules/groups/repositories/typeorm/GuessTypeOrmRepository.ts
@@ -2,13 +2,34 @@ import { getRepository, Repository } from 'typeorm';
 
 import { ICreateGuessDTO } from '@modules/groups/dtos/ICreateGuessDTO';
 import { Guess } from '@modules/groups/entities/Guess';
-import { IGuessRepository } from '../IGuessRepository';
+import { IGroupMatchUser, IGuessRepository } from '../IGuessRepository';
 
 class GuessTypeOrmRepository implements IGuessRepository {
   private repository: Repository<Guess>;
 
   constructor() {
     this.repository = getRepository(Guess);
+  }
+
+  async findByGroupMatchUser({
+    group_id,
+    match_id,
+    user_id,
+  }: IGroupMatchUser): Promise<Guess> {
+    const found = await this.repository.findOne({
+      user_id,
+      group_id,
+      match_id,
+    });
+    return found;
+  }
+
+  async findByUserId(user_id: string): Promise<Guess[]> {
+    const guesses = await this.repository.find({
+      user_id,
+    });
+
+    return guesses;
   }
 
   async create({

--- a/src/modules/groups/repositories/typeorm/GuessTypeOrmRepository.ts
+++ b/src/modules/groups/repositories/typeorm/GuessTypeOrmRepository.ts
@@ -1,0 +1,37 @@
+import { getRepository, Repository } from 'typeorm';
+
+import { ICreateGuessDTO } from '@modules/groups/dtos/ICreateGuessDTO';
+import { Guess } from '@modules/groups/entities/Guess';
+import { IGuessRepository } from '../IGuessRepository';
+
+class GuessTypeOrmRepository implements IGuessRepository {
+  private repository: Repository<Guess>;
+
+  constructor() {
+    this.repository = getRepository(Guess);
+  }
+
+  async create({
+    id,
+    user_id,
+    group_id,
+    match_id,
+    home_team,
+    away_team,
+  }: ICreateGuessDTO): Promise<Guess> {
+    const newGuess = await this.repository.create({
+      id,
+      user_id,
+      group_id,
+      match_id,
+      home_team,
+      away_team,
+    });
+
+    await this.repository.save(newGuess);
+
+    return newGuess;
+  }
+}
+
+export { GuessTypeOrmRepository };

--- a/src/modules/groups/useCases/createGuess/CreateGuessController.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessController.ts
@@ -4,7 +4,8 @@ import { CreateGuessUseCase } from './CreateGuessUseCase';
 
 class CreateGuessController {
   async handle(request: Request, response: Response): Promise<Response> {
-    const { group_id, match_id, home_team, away_team } = request.body;
+    const { match_id, home_team, away_team } = request.body;
+    const { group_id } = request.params;
     const { id } = request.user;
 
     const createGuess = container.resolve(CreateGuessUseCase);

--- a/src/modules/groups/useCases/createGuess/CreateGuessController.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessController.ts
@@ -1,0 +1,23 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+import { CreateGuessUseCase } from './CreateGuessUseCase';
+
+class CreateGuessController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    const { group_id, match_id, home_team, away_team } = request.body;
+    const { id } = request.user;
+
+    const createGuess = container.resolve(CreateGuessUseCase);
+    const result = await createGuess.execute({
+      user_id: id,
+      group_id,
+      match_id,
+      home_team,
+      away_team,
+    });
+
+    return response.status(201).json(result);
+  }
+}
+
+export { CreateGuessController };

--- a/src/modules/groups/useCases/createGuess/CreateGuessUseCase.spec.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessUseCase.spec.ts
@@ -65,7 +65,7 @@ describe('Create Guess Use Case', () => {
       password: '123',
     });
 
-    const createdGuess = await createGuessUseCase.execute({
+    await createGuessUseCase.execute({
       user_id: user.id,
       group_id: group.id,
       match_id: 7,
@@ -73,7 +73,15 @@ describe('Create Guess Use Case', () => {
       away_team: 0,
     });
 
-    expect(createdGuess).toHaveProperty('id');
+    await expect(() =>
+      createGuessUseCase.execute({
+        user_id: user.id,
+        group_id: group.id,
+        match_id: 7,
+        home_team: 1,
+        away_team: 0,
+      }),
+    ).rejects.toBeInstanceOf(AppError);
   });
 
   it('should not be able to register guess with invalid user', async () => {

--- a/src/modules/groups/useCases/createGuess/CreateGuessUseCase.spec.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessUseCase.spec.ts
@@ -1,0 +1,59 @@
+import { CreateGuessUseCase } from './CreateGuessUseCase';
+import { GuessInMemoryRepository } from '@modules/groups/repositories/inMemory/GuessInMemoryRepository';
+
+import { User } from '@modules/accounts/entities/User';
+import { UserInMemoryRepository } from '@modules/accounts/repositories/inMemory/UserInMemoryRepository';
+import { CreateUserUseCase } from '@modules/accounts/useCases/createUser/CreateUserUseCase';
+
+import { GroupInMemoryRepository } from '@modules/groups/repositories/inMemory/GroupInMemoryRepository';
+import { CreateGroupUseCase } from '../createGroup/CreateGroupUseCase';
+
+import { AppError } from '@shared/errors/AppError';
+
+let createGuessUseCase: CreateGuessUseCase;
+let guessRepository: GuessInMemoryRepository;
+
+let createGroupUseCase: CreateGroupUseCase;
+let groupRepository: GroupInMemoryRepository;
+
+let createUserUseCase: CreateUserUseCase;
+let userRepository: UserInMemoryRepository;
+
+describe('Create Guess Use Case', () => {
+  beforeEach(() => {
+    userRepository = new UserInMemoryRepository();
+    guessRepository = new GuessInMemoryRepository();
+    groupRepository = new GroupInMemoryRepository();
+
+    createGuessUseCase = new CreateGuessUseCase(
+      guessRepository,
+      userRepository,
+      groupRepository,
+    );
+
+    createUserUseCase = new CreateUserUseCase(userRepository);
+
+    // createGroupUseCase = new CreateGroupUseCase(
+    //   groupRepository,
+    //   userRepository,
+    // );
+  });
+
+  it('should be able to register a new guess', async () => {
+    const user = await userRepository.create({
+      name: 'Test User',
+      email: 'test@server.com',
+      password: '123456',
+    });
+
+    const createdGuess = await createGuessUseCase.execute({
+      user_id: user.id,
+      group_id: 'some group',
+      match_id: 7,
+      home_team: 1,
+      away_team: 0,
+    });
+
+    expect(createdGuess).toHaveProperty('id');
+  });
+});

--- a/src/modules/groups/useCases/createGuess/CreateGuessUseCase.spec.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessUseCase.spec.ts
@@ -1,22 +1,18 @@
+import 'reflect-metadata';
 import { CreateGuessUseCase } from './CreateGuessUseCase';
 import { GuessInMemoryRepository } from '@modules/groups/repositories/inMemory/GuessInMemoryRepository';
 
-import { User } from '@modules/accounts/entities/User';
 import { UserInMemoryRepository } from '@modules/accounts/repositories/inMemory/UserInMemoryRepository';
-import { CreateUserUseCase } from '@modules/accounts/useCases/createUser/CreateUserUseCase';
 
 import { GroupInMemoryRepository } from '@modules/groups/repositories/inMemory/GroupInMemoryRepository';
-import { CreateGroupUseCase } from '../createGroup/CreateGroupUseCase';
 
 import { AppError } from '@shared/errors/AppError';
 
 let createGuessUseCase: CreateGuessUseCase;
 let guessRepository: GuessInMemoryRepository;
 
-let createGroupUseCase: CreateGroupUseCase;
 let groupRepository: GroupInMemoryRepository;
 
-let createUserUseCase: CreateUserUseCase;
 let userRepository: UserInMemoryRepository;
 
 describe('Create Guess Use Case', () => {
@@ -30,13 +26,6 @@ describe('Create Guess Use Case', () => {
       userRepository,
       groupRepository,
     );
-
-    createUserUseCase = new CreateUserUseCase(userRepository);
-
-    // createGroupUseCase = new CreateGroupUseCase(
-    //   groupRepository,
-    //   userRepository,
-    // );
   });
 
   it('should be able to register a new guess', async () => {
@@ -46,14 +35,50 @@ describe('Create Guess Use Case', () => {
       password: '123456',
     });
 
+    const group = await groupRepository.create({
+      description: 'test group',
+      owner_id: user.id,
+      password: '123',
+    });
+
     const createdGuess = await createGuessUseCase.execute({
       user_id: user.id,
-      group_id: 'some group',
+      group_id: group.id,
       match_id: 7,
       home_team: 1,
       away_team: 0,
     });
 
     expect(createdGuess).toHaveProperty('id');
+  });
+
+  it('should not be able to register guess with invalid user', async () => {
+    expect(() =>
+      createGuessUseCase.execute({
+        user_id: 'some user id',
+        group_id: 'some group',
+        match_id: 7,
+        home_team: 1,
+        away_team: 0,
+      }),
+    ).rejects.toBeInstanceOf(AppError);
+  });
+
+  it('should not be able to register guess with invalid group', async () => {
+    const user = await userRepository.create({
+      name: 'Test User',
+      email: 'test@server.com',
+      password: '123456',
+    });
+
+    expect(() =>
+      createGuessUseCase.execute({
+        user_id: user.id,
+        group_id: 'some group',
+        match_id: 7,
+        home_team: 1,
+        away_team: 0,
+      }),
+    ).rejects.toBeInstanceOf(AppError);
   });
 });

--- a/src/modules/groups/useCases/createGuess/CreateGuessUseCase.spec.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessUseCase.spec.ts
@@ -52,6 +52,30 @@ describe('Create Guess Use Case', () => {
     expect(createdGuess).toHaveProperty('id');
   });
 
+  it('should not be able to register a guess for a match twice', async () => {
+    const user = await userRepository.create({
+      name: 'Test User',
+      email: 'test@server.com',
+      password: '123456',
+    });
+
+    const group = await groupRepository.create({
+      description: 'test group',
+      owner_id: user.id,
+      password: '123',
+    });
+
+    const createdGuess = await createGuessUseCase.execute({
+      user_id: user.id,
+      group_id: group.id,
+      match_id: 7,
+      home_team: 1,
+      away_team: 0,
+    });
+
+    expect(createdGuess).toHaveProperty('id');
+  });
+
   it('should not be able to register guess with invalid user', async () => {
     expect(() =>
       createGuessUseCase.execute({

--- a/src/modules/groups/useCases/createGuess/CreateGuessUseCase.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessUseCase.ts
@@ -31,6 +31,13 @@ class CreateGuessUseCase {
     if (!group)
       throw new AppError("Cant't register guess with invalid group.", 401);
 
+    const guess = await this.guessRepository.findByGroupMatchUser({
+      group_id,
+      match_id,
+      user_id,
+    });
+    if (guess) throw new AppError("Cant't register guess twice.", 401);
+
     const newGuess = await this.guessRepository.create({
       user_id,
       group_id,

--- a/src/modules/groups/useCases/createGuess/CreateGuessUseCase.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessUseCase.ts
@@ -1,0 +1,33 @@
+import { inject, injectable } from 'tsyringe';
+
+import { IGuessRepository } from '../../repositories/IGuessRepository';
+
+import { Guess } from '@modules/groups/entities/Guess';
+import { ICreateGuessDTO } from '@modules/groups/dtos/ICreateGuessDTO';
+
+@injectable()
+class CreateGuessUseCase {
+  constructor(
+    @inject('GuessRepository') private guessRepository: IGuessRepository,
+  ) {}
+
+  async execute({
+    user_id,
+    group_id,
+    match_id,
+    home_team,
+    away_team,
+  }: ICreateGuessDTO): Promise<Guess> {
+    const newGuess = await this.guessRepository.create({
+      user_id,
+      group_id,
+      match_id,
+      home_team,
+      away_team,
+    });
+
+    return newGuess;
+  }
+}
+
+export { CreateGuessUseCase };

--- a/src/modules/groups/useCases/createGuess/CreateGuessUseCase.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessUseCase.ts
@@ -1,4 +1,3 @@
-import 'reflect-metadata';
 import { inject, injectable } from 'tsyringe';
 
 import { IGuessRepository } from '../../repositories/IGuessRepository';
@@ -26,11 +25,11 @@ class CreateGuessUseCase {
   }: ICreateGuessDTO): Promise<Guess> {
     const user = await this.usersRepository.findById(user_id);
     if (!user)
-      throw new AppError("Can't register guess with invalid user.", 400);
+      throw new AppError("Can't register guess with invalid user.", 401);
 
-    //TODO: implement group repository function findById(id)
-
-    //const group = await this.groupRepository
+    const group = await this.groupRepository.findById(group_id);
+    if (!group)
+      throw new AppError("Cant't register guess with invalid group.", 401);
 
     const newGuess = await this.guessRepository.create({
       user_id,

--- a/src/modules/groups/useCases/createGuess/CreateGuessUseCase.ts
+++ b/src/modules/groups/useCases/createGuess/CreateGuessUseCase.ts
@@ -1,14 +1,20 @@
+import 'reflect-metadata';
 import { inject, injectable } from 'tsyringe';
 
 import { IGuessRepository } from '../../repositories/IGuessRepository';
 
 import { Guess } from '@modules/groups/entities/Guess';
 import { ICreateGuessDTO } from '@modules/groups/dtos/ICreateGuessDTO';
+import { IUserRepository } from '@modules/accounts/repositories/IUserRepository';
+import { AppError } from '@shared/errors/AppError';
+import { IGroupRepository } from '@modules/groups/repositories/IGroupRepository';
 
 @injectable()
 class CreateGuessUseCase {
   constructor(
     @inject('GuessRepository') private guessRepository: IGuessRepository,
+    @inject('UsersRepository') private usersRepository: IUserRepository,
+    @inject('GroupRepository') private groupRepository: IGroupRepository,
   ) {}
 
   async execute({
@@ -18,6 +24,14 @@ class CreateGuessUseCase {
     home_team,
     away_team,
   }: ICreateGuessDTO): Promise<Guess> {
+    const user = await this.usersRepository.findById(user_id);
+    if (!user)
+      throw new AppError("Can't register guess with invalid user.", 400);
+
+    //TODO: implement group repository function findById(id)
+
+    //const group = await this.groupRepository
+
     const newGuess = await this.guessRepository.create({
       user_id,
       group_id,
@@ -25,7 +39,6 @@ class CreateGuessUseCase {
       home_team,
       away_team,
     });
-
     return newGuess;
   }
 }

--- a/src/shared/container/index.ts
+++ b/src/shared/container/index.ts
@@ -6,6 +6,9 @@ import { IUserRepository } from '@modules/accounts/repositories/IUserRepository'
 import { GroupTypeOrmRepository } from '@modules/groups/repositories/typeorm/GroupTypeOrmRepository';
 import { IGroupRepository } from '@modules/groups/repositories/IGroupRepository';
 
+import { GuessTypeOrmRepository } from '@modules/groups/repositories/typeorm/GuessTypeOrmRepository';
+import { IGuessRepository } from '@modules/groups/repositories/IGuessRepository';
+
 container.registerSingleton<IUserRepository>(
   'UsersRepository',
   UserTypeOrmRepository,
@@ -14,4 +17,9 @@ container.registerSingleton<IUserRepository>(
 container.registerSingleton<IGroupRepository>(
   'GroupRepository',
   GroupTypeOrmRepository,
+);
+
+container.registerSingleton<IGuessRepository>(
+  'GuessRepository',
+  GuessTypeOrmRepository,
 );

--- a/src/shared/infra/http/routes/groups.routes.ts
+++ b/src/shared/infra/http/routes/groups.routes.ts
@@ -1,11 +1,18 @@
 import { CreateGroupController } from '@modules/groups/useCases/createGroup/CreateGroupController';
+import { CreateGuessController } from '@modules/groups/useCases/createGuess/CreateGuessController';
 import { Router } from 'express';
 import { ensureAuthenticated } from '../middlewares/ensureAuthenticated';
 
 const createGroupController = new CreateGroupController();
+const createGuessController = new CreateGuessController();
 
 const groupsRoutes = Router();
 
 groupsRoutes.post('/', ensureAuthenticated, createGroupController.handle);
+groupsRoutes.post(
+  '/:group_id/guess',
+  ensureAuthenticated,
+  createGuessController.handle,
+);
 
 export { groupsRoutes };

--- a/src/shared/infra/typeorm/migrations/1641205103045-CreateGuessesTable.ts
+++ b/src/shared/infra/typeorm/migrations/1641205103045-CreateGuessesTable.ts
@@ -1,0 +1,68 @@
+import { MigrationInterface, QueryRunner, Table } from 'typeorm';
+
+export class CreateGuessesTable1641205103045 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.createTable(
+      new Table({
+        name: 'guesses',
+        columns: [
+          {
+            name: 'id',
+            type: 'int',
+            isPrimary: true,
+            isGenerated: true,
+            generationStrategy: 'increment',
+            generatedType: 'STORED',
+          },
+          {
+            name: 'match_id',
+            type: 'int',
+          },
+          {
+            name: 'user_id',
+            type: 'uuid',
+          },
+          {
+            name: 'group_id',
+            type: 'varchar',
+          },
+          {
+            name: 'home_team',
+            type: 'int',
+          },
+          {
+            name: 'away_team',
+            type: 'int',
+          },
+        ],
+        foreignKeys: [
+          {
+            name: 'FK_MatchId',
+            referencedTableName: 'matches',
+            referencedColumnNames: ['id'],
+            columnNames: ['match_id'],
+            onDelete: 'SET NULL',
+          },
+          {
+            name: 'FK_UserId',
+            referencedTableName: 'users',
+            referencedColumnNames: ['id'],
+            columnNames: ['user_id'],
+            onDelete: 'SET NULL',
+          },
+          {
+            name: 'FK_GroupId',
+            referencedTableName: 'groups',
+            referencedColumnNames: ['id'],
+            columnNames: ['group_id'],
+            onDelete: 'SET NULL',
+          },
+        ],
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropTable('guesses');
+  }
+}


### PR DESCRIPTION
Implemented TypeORM entity `Guess.ts`. `id` field is autoincrement

Implemented migration and all foreign keys.

Created the repository interface and implemented TypeORM and InMemory repositories.

Implemented controller and use case.

Implemented tests:

- should be able to register a guess for a match
- should not be able to register a guess with invalid user
- should not be able to register a guess with invalid group
- should not be able to register a guess for a match twice

Registered GuessRepository as a dependency with tsyringe.

Implemented route:

POST `/group/:id/guess`

Example json body

```json
{
	"match_id":2,
	"home_team":2,
	"away_team":1
}
```

Example json response:

```json
{
	"match_id": 2,
	"user_id": "80155d63-3053-45f5-b461-899c9233686b",
	"group_id": "D2kZ74rG",
	"home_team": 2,
	"away_team": 1
}
```
