### PR TITLE
Feature/update match score

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "typeorm": "ts-node-dev -r tsconfig-paths/register ./node_modules/typeorm/cli",
     "test": "NODE_ENV=test jest --runInBand --detectOpenHandles",
     "test:watch": "NODE_ENV=test jest --runInBand --detectOpenHandles --verbose --watchAll",
-    "seed:admin": "ts-node-dev ./src/shared/infra/typeorm/seeds/admin.ts"
+    "seed:admin": "ts-node-dev -r tsconfig-paths/register ./src/shared/infra/typeorm/seeds/admin.ts"
   },
   "dependencies": {
     "bcryptjs": "^2.4.3",

--- a/src/modules/accounts/entities/User.ts
+++ b/src/modules/accounts/entities/User.ts
@@ -24,6 +24,9 @@ class User {
   @Column()
   avatar: string;
 
+  @Column()
+  isAdmin: boolean;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/modules/matches/dtos/ICreateMatchDto.ts
+++ b/src/modules/matches/dtos/ICreateMatchDto.ts
@@ -6,8 +6,8 @@ interface ICreateMatchDTO {
   match_location: string;
   match_stadium: string;
   match_date: Date;
-  home_team_score: number;
-  away_team_score: number;
+  home_team_score?: number;
+  away_team_score?: number;
 }
 
 export { ICreateMatchDTO };

--- a/src/modules/matches/dtos/ICreateMatchDto.ts
+++ b/src/modules/matches/dtos/ICreateMatchDto.ts
@@ -1,11 +1,13 @@
+import { Team } from '../entities/Team';
+
 interface ICreateMatchDTO {
   id?: number;
-  description: string;
-  home_team: string;
-  away_team: string;
-  match_location: string;
-  match_stadium: string;
-  match_date: Date;
+  description?: string;
+  home_team?: string;
+  away_team?: string;
+  match_location?: string;
+  match_stadium?: string;
+  match_date?: Date;
   home_team_score?: number;
   away_team_score?: number;
 }

--- a/src/modules/matches/dtos/ICreateMatchDto.ts
+++ b/src/modules/matches/dtos/ICreateMatchDto.ts
@@ -1,0 +1,13 @@
+interface ICreateMatchDTO {
+  id?: number;
+  description: string;
+  home_team: string;
+  away_team: string;
+  match_location: string;
+  match_stadium: string;
+  match_date: Date;
+  home_team_score: number;
+  away_team_score: number;
+}
+
+export { ICreateMatchDTO };

--- a/src/modules/matches/dtos/IMatchResultDTO.ts
+++ b/src/modules/matches/dtos/IMatchResultDTO.ts
@@ -1,0 +1,7 @@
+interface IMatchResultDTO {
+  match_id: number;
+  home_team_score: number;
+  away_team_score: number;
+}
+
+export { IMatchResultDTO };

--- a/src/modules/matches/entities/Match.ts
+++ b/src/modules/matches/entities/Match.ts
@@ -10,12 +10,18 @@ class Match {
   description: string;
 
   @ManyToOne(() => Team)
-  @JoinColumn({ name: 'country_code' })
-  home_team: Team;
+  @JoinColumn({ name: 'home_team' })
+  home_team_obj: Team;
+
+  @Column()
+  home_team: string;
 
   @ManyToOne(() => Team)
-  @JoinColumn({ name: 'country_code' })
-  away_team: Team;
+  @JoinColumn({ name: 'away_team' })
+  away_team_obj: Team;
+
+  @Column()
+  away_team: string;
 
   @Column()
   match_location: string;

--- a/src/modules/matches/repositories/IMatchRepository.ts
+++ b/src/modules/matches/repositories/IMatchRepository.ts
@@ -1,0 +1,10 @@
+import { IMatchResultDTO } from '../dtos/IMatchResultDTO';
+import { Match } from '../entities/Match';
+
+interface IMatchRepository {
+  findById(match_id: number): Promise<Match>;
+  listAll(): Promise<Match[]>;
+  updateMatch(data: IMatchResultDTO): Promise<Match>;
+}
+
+export { IMatchRepository };

--- a/src/modules/matches/repositories/IMatchRepository.ts
+++ b/src/modules/matches/repositories/IMatchRepository.ts
@@ -1,7 +1,9 @@
+import { ICreateMatchDTO } from '../dtos/ICreateMatchDto';
 import { IMatchResultDTO } from '../dtos/IMatchResultDTO';
 import { Match } from '../entities/Match';
 
 interface IMatchRepository {
+  create(data: ICreateMatchDTO): Promise<Match>;
   findById(match_id: number): Promise<Match>;
   listAll(): Promise<Match[]>;
   updateMatch(data: IMatchResultDTO): Promise<Match>;

--- a/src/modules/matches/repositories/inMemory/MatchInMemoryRepository.ts
+++ b/src/modules/matches/repositories/inMemory/MatchInMemoryRepository.ts
@@ -1,0 +1,50 @@
+import { ICreateMatchDTO } from '@modules/matches/dtos/ICreateMatchDto';
+import { IMatchResultDTO } from '@modules/matches/dtos/IMatchResultDTO';
+import { Match } from '@modules/matches/entities/Match';
+import { IMatchRepository } from '../IMatchRepository';
+
+class MatchInMemoryRepository implements IMatchRepository {
+  matches: Match[] = [];
+
+  create({
+    id,
+    description,
+    home_team,
+    away_team,
+    match_location,
+    match_stadium,
+    match_date,
+    home_team_score,
+    away_team_score,
+  }: ICreateMatchDTO): Promise<Match> {
+    const newMatch = new Match();
+    Object.assign(newMatch, {
+      id,
+      description,
+      home_team,
+      away_team,
+      match_location,
+      match_stadium,
+      match_date,
+      home_team_score,
+      away_team_score,
+    });
+    this.matches.push(newMatch);
+    return Promise.resolve(newMatch);
+  }
+
+  findById(match_id: number): Promise<Match> {
+    const found = this.matches.find(m => m.id === match_id);
+    return Promise.resolve(found);
+  }
+
+  listAll(): Promise<Match[]> {
+    return Promise.resolve(this.matches);
+  }
+
+  updateMatch(data: IMatchResultDTO): Promise<Match> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export { MatchInMemoryRepository };

--- a/src/modules/matches/repositories/inMemory/MatchInMemoryRepository.ts
+++ b/src/modules/matches/repositories/inMemory/MatchInMemoryRepository.ts
@@ -42,8 +42,17 @@ class MatchInMemoryRepository implements IMatchRepository {
     return Promise.resolve(this.matches);
   }
 
-  updateMatch(data: IMatchResultDTO): Promise<Match> {
-    throw new Error('Method not implemented.');
+  updateMatch({
+    match_id,
+    home_team_score,
+    away_team_score,
+  }: IMatchResultDTO): Promise<Match> {
+    const matchIdx = this.matches.findIndex(m => m.id === match_id);
+    if (matchIdx >= 0) {
+      this.matches[matchIdx].home_team_score = home_team_score;
+      this.matches[matchIdx].away_team_score = away_team_score;
+    }
+    return Promise.resolve(this.matches[matchIdx]);
   }
 }
 

--- a/src/modules/matches/repositories/typeorm/MatchTypeOrmRepository.ts
+++ b/src/modules/matches/repositories/typeorm/MatchTypeOrmRepository.ts
@@ -2,12 +2,16 @@ import { getRepository, Repository } from 'typeorm';
 import { IMatchResultDTO } from '@modules/matches/dtos/IMatchResultDTO';
 import { Match } from '@modules/matches/entities/Match';
 import { IMatchRepository } from '../IMatchRepository';
+import { ICreateMatchDTO } from '@modules/matches/dtos/ICreateMatchDto';
 
 class MatchTypeOrmRepository implements IMatchRepository {
   private repository: Repository<Match>;
 
   constructor() {
     this.repository = getRepository(Match);
+  }
+  create(data: ICreateMatchDTO): Promise<Match> {
+    throw new Error('Method not implemented.');
   }
 
   async findById(match_id: number): Promise<Match> {

--- a/src/modules/matches/repositories/typeorm/MatchTypeOrmRepository.ts
+++ b/src/modules/matches/repositories/typeorm/MatchTypeOrmRepository.ts
@@ -3,6 +3,7 @@ import { IMatchResultDTO } from '@modules/matches/dtos/IMatchResultDTO';
 import { Match } from '@modules/matches/entities/Match';
 import { IMatchRepository } from '../IMatchRepository';
 import { ICreateMatchDTO } from '@modules/matches/dtos/ICreateMatchDto';
+import { Team } from '@modules/matches/entities/Team';
 
 class MatchTypeOrmRepository implements IMatchRepository {
   private repository: Repository<Match>;
@@ -10,8 +11,32 @@ class MatchTypeOrmRepository implements IMatchRepository {
   constructor() {
     this.repository = getRepository(Match);
   }
-  create(data: ICreateMatchDTO): Promise<Match> {
-    throw new Error('Method not implemented.');
+  async create({
+    id,
+    description,
+    home_team,
+    away_team,
+    match_date,
+    match_location,
+    match_stadium,
+    home_team_score,
+    away_team_score,
+  }: ICreateMatchDTO): Promise<Match> {
+    const newMatch = this.repository.create({
+      id,
+      description,
+      home_team,
+      away_team,
+      match_date,
+      match_location,
+      match_stadium,
+      home_team_score,
+      away_team_score,
+    });
+
+    await this.repository.save(newMatch);
+
+    return newMatch;
   }
 
   async findById(match_id: number): Promise<Match> {
@@ -23,8 +48,18 @@ class MatchTypeOrmRepository implements IMatchRepository {
     const matches = await this.repository.find();
     return matches;
   }
-  updateMatch(data: IMatchResultDTO): Promise<Match> {
-    throw new Error('Method not implemented.');
+  async updateMatch({
+    match_id,
+    home_team_score,
+    away_team_score,
+  }: IMatchResultDTO): Promise<Match> {
+    const updatedMatch = await this.create({
+      id: match_id,
+      home_team_score,
+      away_team_score,
+    });
+
+    return updatedMatch;
   }
 }
 

--- a/src/modules/matches/repositories/typeorm/MatchTypeOrmRepository.ts
+++ b/src/modules/matches/repositories/typeorm/MatchTypeOrmRepository.ts
@@ -1,0 +1,27 @@
+import { getRepository, Repository } from 'typeorm';
+import { IMatchResultDTO } from '@modules/matches/dtos/IMatchResultDTO';
+import { Match } from '@modules/matches/entities/Match';
+import { IMatchRepository } from '../IMatchRepository';
+
+class MatchTypeOrmRepository implements IMatchRepository {
+  private repository: Repository<Match>;
+
+  constructor() {
+    this.repository = getRepository(Match);
+  }
+
+  async findById(match_id: number): Promise<Match> {
+    const found = await this.repository.findOne({ id: match_id });
+    return found;
+  }
+
+  async listAll(): Promise<Match[]> {
+    const matches = await this.repository.find();
+    return matches;
+  }
+  updateMatch(data: IMatchResultDTO): Promise<Match> {
+    throw new Error('Method not implemented.');
+  }
+}
+
+export { MatchTypeOrmRepository };

--- a/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultController.ts
+++ b/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultController.ts
@@ -4,10 +4,15 @@ import { UpdateMatchResultUseCase } from './UpdateMatchResultUseCase';
 
 class UpdateMatchResultController {
   async handle(request: Request, response: Response): Promise<Response> {
-    const { param1, param2 } = request.body;
+    const { home_team_score, away_team_score } = request.body;
+    const { match_id } = request.params;
 
     const updateMatchResult = container.resolve(UpdateMatchResultUseCase);
-    const result = await updateMatchResult.execute();
+    const result = await updateMatchResult.execute({
+      match_id: parseInt(match_id),
+      home_team_score,
+      away_team_score,
+    });
 
     return response.status(201).json(result);
   }

--- a/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultController.ts
+++ b/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultController.ts
@@ -1,0 +1,16 @@
+import { Request, Response } from 'express';
+import { container } from 'tsyringe';
+import { UpdateMatchResultUseCase } from './UpdateMatchResultUseCase';
+
+class UpdateMatchResultController {
+  async handle(request: Request, response: Response): Promise<Response> {
+    const { param1, param2 } = request.body;
+
+    const updateMatchResult = container.resolve(UpdateMatchResultUseCase);
+    const result = await updateMatchResult.execute();
+
+    return response.status(201).json(result);
+  }
+}
+
+export { UpdateMatchResultController };

--- a/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.spec.ts
+++ b/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.spec.ts
@@ -1,0 +1,33 @@
+import { MatchInMemoryRepository } from '@modules/matches/repositories/inMemory/MatchInMemoryRepository';
+import { UpdateMatchResultUseCase } from './UpdateMatchResultUseCase';
+
+let updateMatch: UpdateMatchResultUseCase;
+let matchRepository: MatchInMemoryRepository;
+
+describe('Update Match Results Use Case', () => {
+  beforeEach(() => {
+    matchRepository = new MatchInMemoryRepository();
+    updateMatch = new UpdateMatchResultUseCase(matchRepository);
+  });
+
+  it('should be able to update a match result', async () => {
+    const match = await matchRepository.create({
+      description: 'Test Match',
+      match_location: 'Testville - TN',
+      match_stadium: 'Tests Arena',
+      match_date: new Date(),
+      home_team: 'bra',
+      away_team: 'arg',
+    });
+
+    await updateMatch.execute({
+      match_id: match.id,
+      home_team_score: 3,
+      away_team_score: 0,
+    });
+
+    const foundMatch = await matchRepository.findById(match.id);
+    expect(foundMatch.home_team_score).toBe(3);
+    expect(foundMatch.away_team_score).toBe(0);
+  });
+});

--- a/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
+++ b/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
@@ -1,0 +1,20 @@
+import { inject, injectable } from 'tsyringe';
+
+import { IMatchRepository } from '../../repositories/IMatchRepository';
+
+import { Match } from '@modules/matches/entities/Match';
+
+@injectable()
+class UpdateMatchResultUseCase {
+  constructor(
+    @inject('MatchRepository') private matchRepository: IMatchRepository,
+  ) {}
+
+  async execute(): Promise<Match> {
+    const result = await this.matchRepository.action();
+
+    return result;
+  }
+}
+
+export { UpdateMatchResultUseCase };

--- a/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
+++ b/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
@@ -16,7 +16,6 @@ class UpdateMatchResultUseCase {
     home_team_score,
     away_team_score,
   }: IMatchResultDTO): Promise<Match> {
-    //TODO: implement this method in TypeORM Repository
     const result = await this.matchRepository.updateMatch({
       match_id,
       home_team_score,

--- a/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
+++ b/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
@@ -3,6 +3,7 @@ import { inject, injectable } from 'tsyringe';
 import { IMatchRepository } from '../../repositories/IMatchRepository';
 
 import { Match } from '@modules/matches/entities/Match';
+import { IMatchResultDTO } from '@modules/matches/dtos/IMatchResultDTO';
 
 @injectable()
 class UpdateMatchResultUseCase {
@@ -10,8 +11,16 @@ class UpdateMatchResultUseCase {
     @inject('MatchRepository') private matchRepository: IMatchRepository,
   ) {}
 
-  async execute(): Promise<Match> {
-    const result = await this.matchRepository.updateMatch();
+  async execute({
+    match_id,
+    home_team_score,
+    away_team_score,
+  }: IMatchResultDTO): Promise<Match> {
+    const result = await this.matchRepository.updateMatch({
+      match_id,
+      home_team_score,
+      away_team_score,
+    });
 
     return result;
   }

--- a/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
+++ b/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
@@ -16,6 +16,7 @@ class UpdateMatchResultUseCase {
     home_team_score,
     away_team_score,
   }: IMatchResultDTO): Promise<Match> {
+    //TODO: implement this method in TypeORM Repository
     const result = await this.matchRepository.updateMatch({
       match_id,
       home_team_score,

--- a/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
+++ b/src/modules/matches/useCases/updateMatchResult/UpdateMatchResultUseCase.ts
@@ -11,7 +11,7 @@ class UpdateMatchResultUseCase {
   ) {}
 
   async execute(): Promise<Match> {
-    const result = await this.matchRepository.action();
+    const result = await this.matchRepository.updateMatch();
 
     return result;
   }

--- a/src/shared/container/index.ts
+++ b/src/shared/container/index.ts
@@ -8,6 +8,8 @@ import { IGroupRepository } from '@modules/groups/repositories/IGroupRepository'
 
 import { GuessTypeOrmRepository } from '@modules/groups/repositories/typeorm/GuessTypeOrmRepository';
 import { IGuessRepository } from '@modules/groups/repositories/IGuessRepository';
+import { IMatchRepository } from '@modules/matches/repositories/IMatchRepository';
+import { MatchTypeOrmRepository } from '@modules/matches/repositories/typeorm/MatchTypeOrmRepository';
 
 container.registerSingleton<IUserRepository>(
   'UsersRepository',
@@ -22,4 +24,9 @@ container.registerSingleton<IGroupRepository>(
 container.registerSingleton<IGuessRepository>(
   'GuessRepository',
   GuessTypeOrmRepository,
+);
+
+container.registerSingleton<IMatchRepository>(
+  'MatchRepository',
+  MatchTypeOrmRepository,
 );

--- a/src/shared/infra/http/app.ts
+++ b/src/shared/infra/http/app.ts
@@ -8,6 +8,7 @@ import createConnection from '../typeorm';
 import { usersRoutes } from './routes/users.routes';
 import { authRoutes } from './routes/authentication.routes';
 import { groupsRoutes } from './routes/groups.routes';
+import { matchRoutes } from './routes/matches.routes';
 
 import { AppError } from '@shared/errors/AppError';
 
@@ -22,6 +23,7 @@ app.use(express.json());
 app.use('/users', usersRoutes);
 app.use('/auth', authRoutes);
 app.use('/groups', groupsRoutes);
+app.use('/matches', matchRoutes);
 
 app.get('/', (request, response) =>
   response.status(200).json({

--- a/src/shared/infra/http/middlewares/ensureAdmin.ts
+++ b/src/shared/infra/http/middlewares/ensureAdmin.ts
@@ -1,0 +1,28 @@
+import auth from '@config/auth';
+import { GetUserRepository } from '@shared/container/GetUserRepository';
+import { AppError } from '@shared/errors/AppError';
+import { Request, Response, NextFunction } from 'express';
+import { verify } from 'jsonwebtoken';
+import { container } from 'tsyringe';
+
+interface IPayload {
+  sub: string;
+}
+
+export async function ensureAdmin(
+  request: Request,
+  response: Response,
+  next: NextFunction,
+) {
+  const { id } = request.user;
+  if (!id) throw new AppError('No user found!', 401);
+
+  const repository = container.resolve(GetUserRepository).getRepository();
+
+  const found = await repository.findById(id);
+  if (!found) throw new AppError('User id not found', 401);
+
+  if (!found.isAdmin) throw new AppError('User is not admin', 403);
+
+  next();
+}

--- a/src/shared/infra/http/routes/matches.routes.ts
+++ b/src/shared/infra/http/routes/matches.routes.ts
@@ -1,0 +1,17 @@
+import { UpdateMatchResultController } from '@modules/matches/useCases/updateMatchResult/UpdateMatchResultController';
+import { Router } from 'express';
+import { ensureAdmin } from '../middlewares/ensureAdmin';
+import { ensureAuthenticated } from '../middlewares/ensureAuthenticated';
+
+const updateMatchResultController = new UpdateMatchResultController();
+
+const matchRoutes = Router();
+
+matchRoutes.post(
+  '/:match_id/result',
+  ensureAuthenticated,
+  ensureAdmin,
+  updateMatchResultController.handle,
+);
+
+export { matchRoutes };

--- a/src/shared/infra/typeorm/seeds/admin.ts
+++ b/src/shared/infra/typeorm/seeds/admin.ts
@@ -1,3 +1,5 @@
+import 'reflect-metadata';
+
 import { hash } from 'bcryptjs';
 import { v4 as uuidV4 } from 'uuid';
 


### PR DESCRIPTION
- [x]  **Validate admin user**
    
    Middleware `ensureAdmin.ts`
    
    Route POST `/matches/:match_id/result`
    
    json body
    
    ```json
    {
    	"home_team_score":3,
    	"away_team_score":0
    }
    ```
    
    json response
    
    ```json
    {
    	"id": 2,
    	"home_team_score": 3,
    	"away_team_score": 0
    }
    ```
    
- [x]  UseCase
    
    Implemented match repository interface
    
    - [x]  create
    - [x]  findByMatchId
    - [x]  listAll
    - [x]  updateMatch
    
    Implemented `IUpdateMatchResultDTO.ts`
    
    Implemented TypeORM repository
    
    Implemented InMemory repository to run tests
    
    Implemented a `create` method in repository interface so it is possible to create matches for testing purposes
    
    `create` method is not implemented in TypeORM because matches will be seeded into the database
    
    **Tests**
    
    - [x]  should be able to update a match result